### PR TITLE
Add filter for fields to be rendered

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Here is an example that renders a Laposta form. You can change and style this ex
     {{ csrfInput() }}
     {{ actionInput('laposta/submit') }}
     {{ redirectInput('url_to_redirect_to') }}
-    {% for field in entry.form %}
+    {% for field in entry.form|filter(field => field.inform == "true") %}
       {% switch field.type %}
         {% case 'radio' or 'checkbox' %}
           {% for option in field.options %}

--- a/src/fields/Laposta.php
+++ b/src/fields/Laposta.php
@@ -79,6 +79,7 @@ class Laposta extends Dropdown
                     'required' => true,
                     'value' => $list,
                     'options' => [],
+                    'inform' => 'true',
                 ],
             ];
 
@@ -92,6 +93,7 @@ class Laposta extends Dropdown
                     'required' => $result['field']['required'],
                     'value' => $result['field']['defaultvalue'],
                     'options' => $result['field']['options'] ?? [],
+                    'inform' => $result['field']['in_form'],
                 ];
             }
         } catch (\Exception) {


### PR DESCRIPTION
In LaPosta you can set per field whether you would like to display it in the form or not (default is “visible”),  by adding this the plugin only renders the fields that are enabled in LaPosta. 

This might be useful when importing subscribers from other mailing services containing data the you would like to save but not display in the rendered form as a field (e.g. opt-in dates). 